### PR TITLE
Fix compiler warning pertaining to deprecated method

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -442,7 +442,7 @@ void MainWindow::setupSettingsModal() {
 
 void MainWindow::addressBook() {
     // Check to see if there is a target.
-    QRegExp re("Address[0-9]+", Qt::CaseInsensitive);
+    QRegularExpression re("Address[0-9]+", QRegularExpression::CaseInsensitiveOption);
     for (auto target: ui->sendToWidgets->findChildren<QLineEdit *>(re)) {
         if (target->hasFocus()) {
             AddressBook::open(this, target);

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -132,7 +132,7 @@ void MainWindow::updateLabelsAutoComplete() {
     labelCompleter->setCaseSensitivity(Qt::CaseInsensitive);
 
     // Then, find all the address fields and update the completer.
-    QRegExp re("Address[0-9]+", Qt::CaseInsensitive);
+    QRegularExpression re("Address[0-9]+", QRegularExpression::CaseInsensitiveOption);
     for (auto target: ui->sendToWidgets->findChildren<QLineEdit *>(re)) {
         target->setCompleter(labelCompleter);
     }


### PR DESCRIPTION
Example error before PR:
```
‘QList<T> QObject::findChildren(const QRegExp&, Qt::FindChildOptions) const [with T = QLineEdit*; Qt::FindChildOptions = QFlags<Qt::FindChildOption>]’ is deprecated: Use findChildren(const QRegularExpression &, ...) instead. [-Wdeprecated-declarations]
```

This commit updates this line to the non-deprecated QT5 version of this
method, which uses QRegularExpression rather than QRegExp, thus removing
the warning.