### PR TITLE
Put all theme name to 'unfinished' + translation correction

### DIFF
--- a/res/silentdragon_de.ts
+++ b/res/silentdragon_de.ts
@@ -2019,22 +2019,22 @@ You either have unconfirmed funds or the balance is too low for an automatic mig
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_fil.ts
+++ b/res/silentdragon_fil.ts
@@ -1847,22 +1847,22 @@ Would you like to visit the releases page?</source>
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>default</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>asul</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>liwanag</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>madilim</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_fr.ts
+++ b/res/silentdragon_fr.ts
@@ -1328,7 +1328,7 @@ If all else fails, please run hushd manually.</source>
     <message>
         <location filename="../src/rpc.cpp" line="1240"/>
         <source>Waiting for hushd to exit, y&apos;all</source>
-        <translation>Veuillez atendre que hushd soit arrêté, vous tous</translation>
+        <translation>Veuillez attendre que hushd soit arrêté.</translation>
     </message>
     <message>
         <source>hushd has no peer connections</source>
@@ -2000,22 +2000,22 @@ Vous avez soit des fonds non confirmés soit le solde est trop petit pour une mi
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>défaut</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>Bleu</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>Calire</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>Sombre</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_hr.ts
+++ b/res/silentdragon_hr.ts
@@ -1850,22 +1850,22 @@ Would you like to visit the releases page?</source>
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>početno</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>plavo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>svijetlo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>tamno</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_id.ts
+++ b/res/silentdragon_id.ts
@@ -1842,22 +1842,22 @@ Would you like to visit the releases page?</source>
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>Standar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>Biru</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>Cerah</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>Gelap</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_nl.ts
+++ b/res/silentdragon_nl.ts
@@ -2051,6 +2051,26 @@ Je hebt nog onbevestigde transacties of je saldo is te laag voor een automatisch
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/settings.ui" line="415"/>
+        <source>default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings.ui" line="420"/>
+        <source>blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings.ui" line="425"/>
+        <source>light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings.ui" line="430"/>
+        <source>dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/settings.ui" line="435"/>
         <source>midnight</source>
         <translation type="unfinished"></translation>

--- a/res/silentdragon_ro.ts
+++ b/res/silentdragon_ro.ts
@@ -1844,22 +1844,22 @@ Doriti sa vizitati pagina veriunii?</translation>
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>mod implicit</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>albastru</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>deschis</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>inchis</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>

--- a/res/silentdragon_sr.ts
+++ b/res/silentdragon_sr.ts
@@ -1850,22 +1850,22 @@ Would you like to visit the releases page?</source>
     <message>
         <location filename="../src/settings.ui" line="415"/>
         <source>default</source>
-        <translation>početno</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="420"/>
         <source>blue</source>
-        <translation>plavo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="425"/>
         <source>light</source>
-        <translation>svetlo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="430"/>
         <source>dark</source>
-        <translation>tamno</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/settings.ui" line="435"/>


### PR DESCRIPTION
- Put all theme name to 'unfinished' to avoid theme change problems.
- Little French translation correction